### PR TITLE
Fix 'suggest edit' button in docs, add devcontainer support for Apple Silicon

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,6 +6,7 @@
 ##
 ##  Author(s):
 ##  - Markus Braun, :em engineering methods AG (contracted by Robert Bosch GmbH)
+##  - Stefan Schulz, itemis AG (contracted by Robert Bosch GmbH)
 ## =====================================================================================
 ##
 
@@ -50,8 +51,12 @@ USER vscode
 RUN curl -sSL https://install.python-poetry.org | python3 -
 
 # Install dart-sass (needed for scoping css files to specific html elements)
-RUN curl -sSL https://github.com/sass/dart-sass/releases/download/1.49.7/dart-sass-1.49.7-linux-x64.tar.gz | \
-    tar -xzvf - --strip-components=1 -C /home/vscode/.local/bin dart-sass/sass
+# Some dart-sass versions ship with a src folder, which contains the dart binary so we need to extract all
+# contents of the tarball. Note that this will create a src folder in /home/vscode/.local/bin.
+RUN export PLATFORM="$(uname -m | sed 's/aarch64/arm64/' | sed 's/86_//')" && \
+    echo Installing dart-sass for $PLATFORM && \
+    curl -sSL https://github.com/sass/dart-sass/releases/download/1.52.3/dart-sass-1.52.3-linux-${PLATFORM}.tar.gz | \
+    tar -xzvf - --strip-components=1 -C /home/vscode/.local/bin dart-sass/
 
 # configure poetry completion
 RUN poetry completions zsh > ~/.oh-my-zsh/plugins/poetry/_poetry

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -35,3 +35,5 @@ Please keep the list sorted.
   * Nirmal Sasidharan - <nirmal.sasidharan@de.bosch.com>
 * :em engineering methods AG
   * Markus Braun - <markus.braun@em.ag>
+* itemis AG
+  * Stefan Schulz - <stefan.schulz@itemis.com>

--- a/conf_utils.py
+++ b/conf_utils.py
@@ -5,6 +5,7 @@
 #
 #  Author(s):
 #  - Markus Braun, :em engineering methods AG (contracted by Robert Bosch GmbH)
+#  - Stefan Schulz, itemis AG (contracted by Robert Bosch GmbH)
 # =====================================================================================
 """Some helper functions for conf.py."""
 import datetime
@@ -65,6 +66,7 @@ def theme_options(theme: str) -> Dict[str, Any]:
             "repository_url": "https://github.com/boschglobal/doxysphinx",
             "use_repository_button": True,
             "use_edit_page_button": True,
+            "repository_branch": "main",
             "logo_only": True,
             "show_navbar_depth": 5,
             "home_page_in_toc": True,


### PR DESCRIPTION
I've noticed that the 'suggest edit' buttons in the [generated documentation](https://boschglobal.github.io/doxysphinx/) do not work properly, because sphinx_book_theme assumes `master` as the name of the default branch.
This PR sets the correct branch for the theme.

While trying to check the correctness of my fix, I've also noticed that the devcontainer does not work on Apple Silicon (arm64) machines. This is because the Dockerfile always downloads and installs the x64 build of dart-sass, which is incompatible to arm64. I've modified the Dockerfile so that it checks the target platform of the Docker image and downloads the according dart-sass build.

Here's a quick rundown on the `uname -m | sed 's/aarch64/arm64/' | sed 's/86_//`  command which used to decide the correct dart-sass build:
- `uname -m` prints the architecture of the host machine.
-  `sed 's/aarch64/arm64/'` aarch64 is the Linux equivalent of Apple's arm64 (in fact, both are now [identical](https://www.phoronix.com/scan.php?page=news_item&px=MTY5ODk)). dart-sass builds for this architecture are released named `arm64`.
- `sed 's/86_//'` on x64 based machines, `uname -m` returns `x86_64`. dart-sass drops the `86_` in their builds.