### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ documentation = "https://boschglobal.github.io/doxysphinx/"
 readme = "README.md"
 keywords = ["DaC", "docs-as-code", "doxygen", "sphinx"]
 classifiers = [
+    "Framework :: Sphinx :: Extension",
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Documentation",
     "Topic :: Software Development :: Pre-processors",


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).

You may also want to add the [sphinx-extension](https://github.com/topics/sphinx-extension) repo topic, there are 200 other extensions using it.