### PR TITLE
Don't launch doxygen from a shell

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -40,3 +40,5 @@ Please keep the list sorted.
   * Markus Braun - <markus.braun@em.ag>
 * itemis AG
   * Stefan Schulz - <stefan.schulz@itemis.com>
+* Stream HPC B.V.
+  * Gergely Meszaros <gergely@streamhpc.com>


### PR DESCRIPTION
Use `shutil.which` to resolve the path to doxygen instead of starting the subprocess in a shell. This makes sure that shell constructs aren't interpreted in the `--doxygen_exe` option.

E.g. the following now works:
`doxysphinx build --doxygen_exe '/path/with spaces/to/doxygen' ...`