### PR TITLE
fix(doxygen_cwd): Interpret paths relative to working dir

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -40,3 +40,5 @@ Please keep the list sorted.
   * Markus Braun - <markus.braun@em.ag>
 * itemis AG
   * Stefan Schulz - <stefan.schulz@itemis.com>
+* Stream HPC B.V.
+  * Gergely Meszaros <gergely@streamhpc.com>

--- a/doxysphinx/cli.py
+++ b/doxysphinx/cli.py
@@ -6,6 +6,7 @@
 #  Author(s):
 #  - Markus Braun, :em engineering methods AG (contracted by Robert Bosch GmbH)
 #  - Celina Adelhardt, :em engineering methods AG (contracted by Robert Bosch GmbH)
+#  - Gergely Meszaros, Stream HPC B.V. (contracted by Advanced Micro Devices Inc.)
 # =====================================================================================
 
 # noqa: D301
@@ -161,7 +162,7 @@ def _get_outdir_via_doxyfile(doxyfile: Path, sphinx_source: Path, doxy_context: 
     config = read_doxyconfig(doxyfile, doxy_context.doxygen_exe, doxy_context.doxygen_cwd)
 
     validator = DoxygenSettingsValidator()
-    if not validator.validate(config, sphinx_source):
+    if not validator.validate(config, sphinx_source, doxy_context.doxygen_cwd):
         if any(item for item in validator.validation_errors if not item.startswith("Hint:")):
             message = validator.validation_msg
             raise click.UsageError(

--- a/doxysphinx/doxygen.py
+++ b/doxysphinx/doxygen.py
@@ -6,6 +6,7 @@
 #  Author(s):
 #  - Markus Braun, :em engineering methods AG (contracted by Robert Bosch GmbH)
 #  - Celina Adelhardt, :em engineering methods AG (contracted by Robert Bosch GmbH)
+#  - Gergely Meszaros, Stream HPC B.V. (contracted by Advanced Micro Devices Inc.)
 # =====================================================================================
 """The doxygen module contains classes and functions specific to doxygen."""
 
@@ -169,17 +170,18 @@ class DoxygenSettingsValidator:
     validation_msg = ""
     """Validation errors merged in one string."""
 
-    def validate(self, config: ConfigDict, sphinx_source_dir: Path) -> bool:
+    def validate(self, config: ConfigDict, sphinx_source_dir: Path, doxygen_cwd: Path) -> bool:
         """Validate the doxygen configuration regarding the output directory, mandatory and optional settings.
 
         :param config: the imported doxyfile.
         :param sphinx_source_dir: the sphinx directory (necessary for output directory validation).
+        :param doxygen_cwd the directory for doxygen, paths from doxyfile are relative from here
         :return: False, if there is a deviation to the defined mandatory or optional settings.
         """
         if "WARNINGS" in config:
             self.validation_errors.extend(config["WARNINGS"])
 
-        out_dir_validated = self._validate_doxygen_out_dirs(config, sphinx_source_dir)
+        out_dir_validated = self._validate_doxygen_out_dirs(config, sphinx_source_dir, doxygen_cwd)
         recommended_settings_validated = self._validate_doxygen_recommended_settings(config)
         optional_settings_validated = self._validate_doxygen_optional_settings(config)
         if out_dir_validated and recommended_settings_validated and optional_settings_validated:
@@ -190,23 +192,24 @@ class DoxygenSettingsValidator:
                 self.validation_msg += error + "\n"
             return False
 
-    def _validate_doxygen_out_dirs(self, config: ConfigDict, sphinx_source_dir: Path) -> bool:
+    def _validate_doxygen_out_dirs(self, config: ConfigDict, sphinx_source_dir: Path, doxygen_cwd: Path) -> bool:
         """
         Validate the output directory given from doxyfile and set the required values in mandatory settings.
 
         :param out_dir: output directory value in doxyfile.
         :param sphinx_source_dir: sphinx docs source-directory.
+        :param doxygen_cwd the directory for doxygen, paths from doxyfile are relative from here
         :return: True if doxygen output directory is located inside the sphinx docs root,
         False if not and doxysphinx should exit.
         """
-        out = Path(str(config["OUTPUT_DIRECTORY"])) / "html"  # config["HTML_OUTPUT"]
+        out = Path(doxygen_cwd) / str(config["OUTPUT_DIRECTORY"]) / "html"  # config["HTML_OUTPUT"]
         self.absolute_out = path_resolve(out)
         stringified_out = str(out) if out.is_absolute() else f'"{out}" (resolved to "{self.absolute_out}")'
 
         self.mandatory_settings["OUTPUT_DIRECTORY"] = str(config["OUTPUT_DIRECTORY"])
 
         if path_is_relative_to(out, sphinx_source_dir):
-            self.optional_settings["GENERATE_TAGFILE"] = str(out) + "/tagfile.xml"
+            self.optional_settings["GENERATE_TAGFILE"] = os.path.relpath(out / "tagfile.xml", doxygen_cwd)
             return True
         else:
             self.optional_settings["GENERATE_TAGFILE"] = "docs/doxygen/demo/html/tagfile.xml"  # default value

--- a/tests/doxygen/test_doxysettings_validator.py
+++ b/tests/doxygen/test_doxysettings_validator.py
@@ -5,6 +5,7 @@
 #
 #  Author(s):
 #  - Celina Adelhardt, :em engineering methods AG (contracted by Robert Bosch GmbH)
+#  - Gergely Meszaros, Stream HPC B.V. (contracted by Advanced Micro Devices Inc.)
 # =====================================================================================
 
 from pathlib import Path
@@ -93,7 +94,7 @@ def test_doxysettings_validation(
     validator, working_directory, test_dict: ConfigDict, expected_validation_errors: List[str]
 ):
     validator.validation_errors.clear()
-    validator.validate(test_dict, working_directory)
+    validator.validate(test_dict, working_directory, working_directory)
     assert validator.validation_errors == expected_validation_errors
 
 


### PR DESCRIPTION
Paths in the doxyfile are now interpreted relative to the doxygen working directory.