### PR TITLE
fix: Windows long paths

### DIFF
--- a/.github/actions/init/action.yaml
+++ b/.github/actions/init/action.yaml
@@ -23,19 +23,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: "Ensure doxygen"
-    if: inputs.doc-tools
+  - name: "Ensure doxygen (Linux)"
+    if: inputs.doc-tools && runner.os == 'Linux'
     run: sudo apt-get install graphviz doxygen -y
-    # latest doxygen (untested)
-    # run: |
-    #  if ! command -v doxygen &> /dev/null
-    #  then
-    #    echo "doxygen wasn't found... installing now..."
-    #    mkdir -p ~/.local/bin
-    #    curl -sSL https://www.doxygen.nl/files/doxygen-1.9.4.linux.bin.tar.gz | \
-    #    tar -xzvf - --strip-components=1 -C ~/.local/bin bin/doxygen;
-    #  fi
+    shell: bash
 
+  - name: "Ensure doxygen (Windows)"
+    if: inputs.doc-tools && runner.os == 'Windows'
+    run: |
+      choco install doxygen.install graphviz --yes
     shell: bash
 
   - name: "Ensure poetry"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       run: |
         mkdir -p docs/doxygen
         poetry run pytest --emoji -v -s --md $GITHUB_STEP_SUMMARY
+      shell: bash
 
   qa:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,11 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - name: "Checkout Code"

--- a/doxysphinx/utils/files.py
+++ b/doxysphinx/utils/files.py
@@ -137,7 +137,7 @@ def copy_if_different(
         source_file = file
         target_file = target_dir / source_file.relative_to(source_dir)
         target_file.parent.mkdir(parents=True, exist_ok=True)
-        if os.name == 'nt':
+        if os.name == "nt":
             # Use extended-length paths on Windows to support long file names
             source_file = Path(rf"\\?\{source_file}")
             target_file = Path(rf"\\?\{target_file}")

--- a/doxysphinx/utils/files.py
+++ b/doxysphinx/utils/files.py
@@ -138,8 +138,9 @@ def copy_if_different(
         target_file = target_dir / source_file.relative_to(source_dir)
         target_file.parent.mkdir(parents=True, exist_ok=True)
         if os.name == 'nt':
-            source_file = r"\\?\%s" % source_file
-            target_file = r"\\?\%s" % target_file
+            # Use extended-length paths on Windows to support long file names
+            source_file = Path(rf"\\?\{source_file}")
+            target_file = Path(rf"\\?\{target_file}")
 
         shutil.copy(source_file, target_file)
         result.append(target_file)

--- a/doxysphinx/utils/files.py
+++ b/doxysphinx/utils/files.py
@@ -139,11 +139,11 @@ def copy_if_different(
         target_file.parent.mkdir(parents=True, exist_ok=True)
         if os.name == "nt":
             # Use extended-length paths on Windows to support long file names
-            source_file = Path(rf"\\?\{source_file}")
-            target_file = Path(rf"\\?\{target_file}")
-
-        shutil.copy(source_file, target_file)
-        result.append(target_file)
+            # Apply \\?\ prefix only to the shutil operation, not to pathlib operations
+            shutil.copy(rf"\\?\{source_file}", rf"\\?\{target_file}")
+        else:
+            shutil.copy(source_file, target_file)
+        result.append(target_file)  # Return the original path without prefix
 
     return result
 

--- a/doxysphinx/utils/files.py
+++ b/doxysphinx/utils/files.py
@@ -137,6 +137,10 @@ def copy_if_different(
         source_file = file
         target_file = target_dir / source_file.relative_to(source_dir)
         target_file.parent.mkdir(parents=True, exist_ok=True)
+        if os.name == 'nt':
+            source_file = r"\\?\%s" % source_file
+            target_file = r"\\?\%s" % target_file
+
         shutil.copy(source_file, target_file)
         result.append(target_file)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,6 +8,7 @@
 # =====================================================================================
 
 from pathlib import Path
+import shutil
 
 from click.testing import CliRunner
 
@@ -39,9 +40,47 @@ def test_build_is_working_as_expected():
         print("Build had errors - std output stream:")
         print(result.stdout)
     assert result.exit_code == 0
-    print("test2")
     assert (repo_root / ".build/html/docs/doxygen/demo/html/doxygen.css").exists()
-    print("test3")
+
+
+def test_longpath_build():
+    """Test building with long paths"""
+    runner = CliRunner()
+    repo_root = path_resolve(Path())
+
+    # Copy our demo directory to a very long path
+    # The path needs to be over 255 characters long to trigger issues on Windows
+    # Windows has a max path length of 255 characters by default
+    # (see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation)
+    long_dir_name = ("long/" * 70) + "path"
+    long_path = repo_root / long_dir_name
+    shutil.copytree(repo_root, long_path, dirs_exist_ok=True)
+
+    sphinx_source = long_path
+    sphinx_output = long_path / ".build/html"
+    doxyfile = long_path / "demo" / "demo.doxyfile"
+
+    result = runner.invoke(
+        cli,
+        [
+            "--verbosity=DEBUG",
+            "build",
+            "--doxygen_cwd",
+            str(long_path),
+            str(sphinx_source),
+            str(sphinx_output),
+            str(doxyfile),
+        ],
+    )
+    assert (long_path / "pyproject.toml").exists()
+    if result.exit_code != 0:
+        print("Build had errors - std output stream:")
+        print(result.stdout)
+    assert result.exit_code == 0
+    assert (long_path / ".build/html/docs/doxygen/demo/html/doxygen.css").exists()
+
+    # Clean up
+    shutil.rmtree(long_path)
 
 
 def test_worker_limiting():
@@ -85,9 +124,7 @@ def test_worker_limiting():
         print("Build had errors - std output stream:")
         print(result.stdout)
     assert result.exit_code == 0
-    print("test2")
     assert (repo_root / ".build/html/docs/doxygen/demo/html/doxygen.css").exists()
-    print("test3")
     assert f"running in parallel with limit of {worker_limit} workers" in result.stdout
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -53,16 +53,29 @@ def test_longpath_build():
     # The path needs to be over 255 characters long to trigger issues on Windows
     # Windows has a max path length of 255 characters by default
     # (see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation)
-    long_dir_name = ("long/" * 70) + "path"
+    long_dir_name = "a" * 250  # Single very long directory name
     long_path = repo_root / long_dir_name
 
-    # Use extended-length paths on Windows to support long file names
+    # Test if we can create the long path at all
     if os.name == "nt":
-        # Apply \\?\ prefix only to the shutil operation, not to pathlib operations
-        shutil.copytree(rf"\\?\{repo_root}", rf"\\?\{long_path}", dirs_exist_ok=True)
+        # On Windows, use extended-length path support
+        try:
+            # Use \\?\ prefix for the actual copy operation
+            shutil.copytree(rf"\\?\{repo_root}", rf"\\?\{long_path}", dirs_exist_ok=True)
+        except OSError as e:
+            raise AssertionError(
+                f"Long path copy failed on Windows - this indicates the tool won't work with long paths: {e}")
     else:
         shutil.copytree(repo_root, long_path, dirs_exist_ok=True)
-    assert (long_path.exists())
+
+    # Verify the copy worked by checking for key files
+    # On Windows with long paths, use os.path.exists with \\?\ prefix for verification
+    if os.name == "nt":
+        assert os.path.exists(rf"\\?\{long_path}"), f"Long path directory was not created: {long_path}"
+        assert os.path.exists(rf"\\?\{long_path}\pyproject.toml"), f"pyproject.toml not found in long path: {long_path}"
+    else:
+        assert long_path.exists(), f"Directory was not created: {long_path}"
+        assert (long_path / "pyproject.toml").exists(), f"pyproject.toml not found: {long_path}"
 
     sphinx_source = long_path
     sphinx_output = long_path / ".build/html"
@@ -80,18 +93,23 @@ def test_longpath_build():
             str(doxyfile),
         ],
     )
-    assert (long_path / "pyproject.toml").exists()
     if result.exit_code != 0:
         print("Build had errors - std output stream:")
         print(result.stdout)
     assert result.exit_code == 0
-    assert (long_path / ".build/html/docs/doxygen/demo/html/doxygen.css").exists()
-
-    # Clean up - use long path prefix on Windows for removal too
+    # Check the final output file
+    css_file_path = long_path / ".build/html/docs/doxygen/demo/html/doxygen.css"
     if os.name == "nt":
-        shutil.rmtree(rf"\\?\{long_path}")
+        assert os.path.exists(rf"\\?\{css_file_path}"), f"Output CSS file missing: {css_file_path}"
     else:
-        shutil.rmtree(long_path)
+        assert css_file_path.exists(), f"Output CSS file missing: {css_file_path}"
+
+    # Clean up - only if the directory was actually created
+    if long_path.exists():
+        if os.name == "nt":
+            shutil.rmtree(rf"\\?\{long_path}")
+        else:
+            shutil.rmtree(long_path)
 
 
 def test_worker_limiting():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -58,9 +58,8 @@ def test_longpath_build():
 
     # Use extended-length paths on Windows to support long file names
     if os.name == "nt":
-        source_path = Path(rf"\\?\{repo_root}")
-        target_path = Path(rf"\\?\{long_path}")
-        shutil.copytree(source_path, target_path, dirs_exist_ok=True)
+        # Apply \\?\ prefix only to the shutil operation, not to pathlib operations
+        shutil.copytree(rf"\\?\{repo_root}", rf"\\?\{long_path}", dirs_exist_ok=True)
     else:
         shutil.copytree(repo_root, long_path, dirs_exist_ok=True)
     assert (long_path.exists())
@@ -90,7 +89,7 @@ def test_longpath_build():
 
     # Clean up - use long path prefix on Windows for removal too
     if os.name == "nt":
-        shutil.rmtree(Path(rf"\\?\{long_path}"))
+        shutil.rmtree(rf"\\?\{long_path}")
     else:
         shutil.rmtree(long_path)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,6 +7,7 @@
 #  - Markus Braun, :em engineering methods AG (contracted by Robert Bosch GmbH)
 # =====================================================================================
 
+import os
 from pathlib import Path
 import shutil
 
@@ -54,7 +55,15 @@ def test_longpath_build():
     # (see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation)
     long_dir_name = ("long/" * 70) + "path"
     long_path = repo_root / long_dir_name
-    shutil.copytree(repo_root, long_path, dirs_exist_ok=True)
+
+    # Use extended-length paths on Windows to support long file names
+    if os.name == "nt":
+        source_path = Path(rf"\\?\{repo_root}")
+        target_path = Path(rf"\\?\{long_path}")
+        shutil.copytree(source_path, target_path, dirs_exist_ok=True)
+    else:
+        shutil.copytree(repo_root, long_path, dirs_exist_ok=True)
+    assert (long_path.exists())
 
     sphinx_source = long_path
     sphinx_output = long_path / ".build/html"
@@ -79,8 +88,11 @@ def test_longpath_build():
     assert result.exit_code == 0
     assert (long_path / ".build/html/docs/doxygen/demo/html/doxygen.css").exists()
 
-    # Clean up
-    shutil.rmtree(long_path)
+    # Clean up - use long path prefix on Windows for removal too
+    if os.name == "nt":
+        shutil.rmtree(Path(rf"\\?\{long_path}"))
+    else:
+        shutil.rmtree(long_path)
 
 
 def test_worker_limiting():


### PR DESCRIPTION
Uses long path prefix on NT systems.
Introduces tests for Windows.

Fixes #156